### PR TITLE
Add flake8-docstrings to tox tests

### DIFF
--- a/tests/test_kata_reactive.py
+++ b/tests/test_kata_reactive.py
@@ -2,31 +2,22 @@ from reactive import kata
 
 
 def test_packages_list():
-    """
-    Assert KATA_PACKAGES is a list
-    of strings.
-    """
+    """Assert KATA_PACKAGES is a list of strings."""
     assert isinstance(kata.KATA_PACKAGES, list)
     for item in kata.KATA_PACKAGES:
         assert isinstance(item, str)
 
 
 def test_install_kata():
-    """
-    Assert install_kata is a method.
-    """
+    """Assert install_kata is a method."""
     assert callable(kata.install_kata)
 
 
 def test_purge_kata():
-    """
-    Assert purge_kata is a method.
-    """
+    """Assert purge_kata is a method."""
     assert callable(kata.purge_kata)
 
 
 def test_publist_config():
-    """
-    Assert publish_config is a method.
-    """
+    """Assert publish_config is a method."""
     assert callable(kata.publish_config)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 120
+ignore = D100
 
 [tox]
 skipsdist = True
@@ -20,6 +21,7 @@ deps =
     pytest
     pytest-cov
     flake8
+    flake8-docstrings
     requests
 commands =
     pytest --cov-report term-missing \


### PR DESCRIPTION
Following on from a code review in Frankfurt, here is an example of enabling docstring tests.