### PR TITLE
Installing kata was failing on jammy

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,14 +4,18 @@ on: [pull_request]
 jobs:
   call-inclusive-naming-check:
     name: Inclusive naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
 
   validate-wheelhouse:
     name: Validate Wheelhouse
     uses: charmed-kubernetes/workflows/.github/workflows/validate-wheelhouse.yaml@main
+    with:
+      python: "['3.8', '3.10']"
 
   lint-unit:
     name: Lint Unit
     uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
+    with:
+      python: "['3.8', '3.10', '3.12']"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 .coverage
 .tox/
 .venv/
+*.charm

--- a/reactive/kata.py
+++ b/reactive/kata.py
@@ -1,6 +1,5 @@
+from urllib.request import urlopen
 import os
-import requests
-
 from subprocess import check_call, check_output
 
 from charmhelpers.core import host
@@ -47,11 +46,13 @@ def install_kata():
 
     if not archive or os.path.getsize(archive) == 0:
         status.maintenance("Installing Kata via apt")
-        gpg_key = requests.get(
+
+        with urlopen(
             "http://download.opensuse.org/repositories/home:/katacontainers:/"
             # wokeignore:rule=master
             "releases:/{}:/master/x{}/Release.key".format(arch, release)
-        ).text
+        ) as response:
+            gpg_key = response.read().decode()
         import_key(gpg_key)
 
         with open("/etc/apt/sources.list.d/kata-containers.list", "w") as f:

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,1 +1,0 @@
-requests


### PR DESCRIPTION
### Overview

Kata charm wouldn't install on jammy due to missing dev libraries in the charm.  `urllib3==2.2.2` was only required because of this charms dependency on `requests`.


### Details
* remove dependency on `requests` library
* updates CI to run woke check
* ignore charms built in the repo
* Addresses [LP#2040498](https://bugs.launchpad.net/bugs/2040498)