### PR TITLE
chore: mark optional requires endpoints as optional in metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,6 +21,7 @@ requires:
   untrusted:
     interface: untrusted-container-runtime
     scope: container
+    optional: true
 resources:
   kata-archive:
     type: file


### PR DESCRIPTION
Mark `untrusted` (requires) as `optional: true`. The charm installs and reaches active status without this relation; `publish_config()` is the only handler gated on `endpoint.untrusted.joined`.